### PR TITLE
Validation

### DIFF
--- a/Generator/Sources/generate/main.swift
+++ b/Generator/Sources/generate/main.swift
@@ -12,7 +12,7 @@ let site = Site<Localization>(
     pageProcessor: PageProcessor(),
     reportProgress: { print($0) })
 
-try site.generate()
+try site.generate().get()
 
 do {
     print("Copying images...")
@@ -22,4 +22,4 @@ do {
 }
 
 
-_ = try? Shell.default.run(command: ["open", repositoryStructure.result.appendingPathComponent("ελ/index.html").path])
+_ = try? Shell.default.run(command: ["open", repositoryStructure.result.appendingPathComponent("ελ/index.html").path]).get()

--- a/Generator/Sources/generate/main.swift
+++ b/Generator/Sources/generate/main.swift
@@ -2,6 +2,7 @@ import Foundation
 
 import SDGCornerstone
 import SDGWeb
+import SDGCommandLine
 
 ProcessInfo.applicationIdentifier = "ελ.ΝΕΜΑΘεσσαλονίκη.Ιστοχώρο"
 
@@ -21,5 +22,18 @@ do {
     fatalError("\(error)")
 }
 
+print("Validating...")
+for (file, errors) in site.validate().sorted(by: { $0.0 < $1.0 }) {
+    print(file.path(relativeTo: repositoryStructure.result).in(FontWeight.bold))
+    for error in errors {
+        let description = error.localizedDescription
+        if (description.contains("\nhref=\u{22}mailto:")) {
+            // Ignore
+        } else {
+            print(error.localizedDescription.formattedAsError())
+            print("")
+        }
+    }
+}
 
 _ = try? Shell.default.run(command: ["open", repositoryStructure.result.appendingPathComponent("ελ/index.html").path]).get()

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "SDGCommandLine",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/SDGCommandLine",
+        "state": {
+          "branch": null,
+          "revision": "cf60a10c41b68ea65eb48ff1c9469a58fc792400",
+          "version": "0.7.1"
+        }
+      },
+      {
         "package": "SDGCornerstone",
         "repositoryURL": "https://github.com/SDGGiesbrecht/SDGCornerstone",
         "state": {
           "branch": null,
-          "revision": "0674531dc65578d95135cc05e79111b132cc3aab",
-          "version": "0.16.0"
+          "revision": "c649f83413bac211d2e8ba13326271147630783d",
+          "version": "0.18.0"
+        }
+      },
+      {
+        "package": "SDGSwift",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/SDGSwift",
+        "state": {
+          "branch": null,
+          "revision": "b12df3622de47ce1c7d5646b3e9b85dc7aaa5b99",
+          "version": "0.10.0"
         }
       },
       {
@@ -15,8 +33,44 @@
         "repositoryURL": "https://github.com/SDGGiesbrecht/SDGWeb",
         "state": {
           "branch": null,
-          "revision": "f6446269d0a0f9b932bde4e12ff0aab380f5afab",
-          "version": "0.0.3"
+          "revision": "ed3f2cbaa94e1be77dfa1acd8618926260898de6",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "CommonMark",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/swift-cmark",
+        "state": {
+          "branch": null,
+          "revision": "861f0db6f553305ad7c40c5df5ab7f9af9e88dd4",
+          "version": "0.0.50000"
+        }
+      },
+      {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/swift-llbuild.git",
+        "state": {
+          "branch": null,
+          "revision": "ed2b4e08e46be355edff390c8aa245e929af1331",
+          "version": "0.0.50000"
+        }
+      },
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/SDGGiesbrecht/swift-package-manager",
+        "state": {
+          "branch": null,
+          "revision": "964c312fc4112dcb24ee71a53ad297db69c1a720",
+          "version": "0.0.50000"
+        }
+      },
+      {
+        "package": "SwiftSyntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax",
+        "state": {
+          "branch": null,
+          "revision": "43aa4a19b8105a803d8149ad2a86aa53a77efef3",
+          "version": "0.50000.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/SDGGiesbrecht/SDGWeb",
         "state": {
           "branch": null,
-          "revision": "ed3f2cbaa94e1be77dfa1acd8618926260898de6",
-          "version": "0.1.0"
+          "revision": "1af1931aa8f70cc393bc088be103720dfcd12359",
+          "version": "0.1.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -8,15 +8,17 @@ let package = Package(
         .macOS(.v10_13)
     ],
     dependencies: [
-        .package(url: "https://github.com/SDGGiesbrecht/SDGCornerstone", .exact(Version(0, 16, 0))),
-        .package(url: "https://github.com/SDGGiesbrecht/SDGWeb", .exact(Version(0, 0, 3)))
+        .package(url: "https://github.com/SDGGiesbrecht/SDGCornerstone", .exact(Version(0, 18, 0))),
+        .package(url: "https://github.com/SDGGiesbrecht/SDGWeb", .exact(Version(0, 1, 0))),
+        .package(url: "https://github.com/SDGGiesbrecht/SDGCommandLine", .exact(Version(0, 7, 1)))
         ],
     targets: [
         .target(
             name: "generate",
             dependencies: [
                 .product(name: "SDGCornerstone", package: "SDGCornerstone"),
-                .product(name: "SDGWeb", package: "SDGWeb")
+                .product(name: "SDGWeb", package: "SDGWeb"),
+                .product(name: "SDGCommandLine", package: "SDGCommandLine")
             ],
             path: "Generator/Sources/generate"),
         ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/SDGGiesbrecht/SDGCornerstone", .exact(Version(0, 18, 0))),
-        .package(url: "https://github.com/SDGGiesbrecht/SDGWeb", .exact(Version(0, 1, 0))),
+        .package(url: "https://github.com/SDGGiesbrecht/SDGWeb", .exact(Version(0, 1, 1))),
         .package(url: "https://github.com/SDGGiesbrecht/SDGCommandLine", .exact(Version(0, 7, 1)))
         ],
     targets: [

--- a/Template/Components/Frame.html
+++ b/Template/Components/Frame.html
@@ -52,7 +52,6 @@
         </div>
         <footer>
             <div>
-                <!-- bottom left -->
             </div>
             <div>
                 <p>[* Πνευματική ιδιοκτησία */* Copyright *] ©[*copyright dates*] [* ΝΕΜΑ Θεσσαλονίκη. Όλα τα δικαιώματα διατηρούνται. */* YWAM Thessaloniki. All rights reserved. *]</p>


### PR DESCRIPTION
After missing the typos last time that prevented the images from displaying, I found some time to fill out the `SDGWeb` library with some better tooling.

I have changed nothing with the site itself, but I have updated the generator to attempt to validate the site immediately after generating it. It will not find everything [W3’s validator](https://validator.w3.org/nu/) does, but it will warn you immediately without you having to go check it separately. For example, it checks for any syntax errors in the HTML files and attempts to open every link to make sure they are pointing at real files (which was what bit us last time).

Merge this, and then generate the site anew to see how it works. You can already see some warnings about things we missed:

- The first few are all because of spaces that should not be between the equals signs and the quotation marks of attribute values (`width= "800"` should be `width="800"`).

- Then it complains about `height` and `width`, which ought to be handled [with CSS](https://www.w3schools.com/cssref/pr_dim_height.asp) instead of in the HTML file.